### PR TITLE
Additional fixes

### DIFF
--- a/src/app/account/account.component.html
+++ b/src/app/account/account.component.html
@@ -1,4 +1,4 @@
-<h1 class="display-4">BLUE Account</h1>
+<h1 class="display-4"> SiMulate</h1> Account</h1>
 
 <div class="container-fluid">
     <div class="row">

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -23,10 +23,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   }));
 
-  it(`should have as title 'Code Blue'`, async(() => {
+  it(`should have as title 'SiMulate'`, async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('Code Blue');
+    expect(app.title).toEqual('SiMulate');
   }));
 
   // it('should render title in a h1 tag', async(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,5 +7,5 @@ import { Component } from '@angular/core';
 export class AppComponent {
     constructor() {
     }
-    title = 'Code Blue';
+    title = 'SiMulate';
 }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -49,7 +49,7 @@
       <clr-checkbox [clrChecked]="includeDraftJobs"  
         [clrInline]="false"
         (change)="toggleStatus('Not Started')">
-          Draft <span class="badge">{{numDraftJobs}}</span>
+          Not Started <span class="badge">{{numDraftJobs}}</span>
       </clr-checkbox> 
     </div>  
   </clr-vertical-nav>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
       <div class="form-group form-filter"> 
-        <p class="p2">x-xx of xxx results for Jobs: {{searchTerm}}</p>
+        <p class="p2">{{numJobStatus}}: {{searchTerm}}</p>
       </div>
   </div>
   <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6 ">

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -27,14 +27,15 @@ export class DashboardComponent implements OnInit {
   includeCompletedJobs:boolean;
   includeRunningJobs:boolean;
   includeDraftJobs:boolean;
+  numJobStatus:string;
   filteredJobs:{info: JobInfo, progress:ProgressInfo} []
 
   constructor(private dashboardService: DashboardService) { }
 
   ngOnInit(): void {
-    // this.numRunningJobs = 0;
-    // this.numCompleteJobs = 0;
-    // this.numDraftJobs = 0;
+    this.numRunningJobs = 0;
+    this.numCompleteJobs = 0;
+    this.numDraftJobs = 0;
     localStorage.removeItem("job_id")
     localStorage.removeItem("template_id")
     this.jobs = []
@@ -48,9 +49,8 @@ export class DashboardComponent implements OnInit {
     this.includeCompletedJobs=true;
     this.includeRunningJobs=true;
     this.includeDraftJobs=true;
-    this.getJobsData()
-    // this.filterJobs();
-    // console.log("get jobs again");
+    this.getJobsData();
+    this.numJobStatus = "";
   }
 
   getJobsData() {
@@ -64,8 +64,21 @@ export class DashboardComponent implements OnInit {
         })
         this.jobsStillLoading = false;
         this.filterJobs();
+        this.setNumJobStatus();
       }
     )
+  }
+
+  setNumJobStatus() {
+    if (this.jobs.length == 0){
+      this.numJobStatus = "No jobs found";  
+    }
+    else if (this.jobs.length == 1) {
+      this.numJobStatus = "1 job found";  
+    }
+    else {
+      this.numJobStatus = this.jobs.length + " jobs found";  
+    }
   }
 
   cancelJob(id){
@@ -168,7 +181,6 @@ export class DashboardComponent implements OnInit {
       if (this.includeDraftJobs) {
         if ((job.info.status.toLowerCase().indexOf('not started') >= 0)
             &&(job.info.name.toLowerCase().indexOf(this.searchTerm.toLowerCase()) >= 0)) {
-              
               this.numDraftJobs++;
           this.filteredJobs.push(job)  
         }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -32,9 +32,9 @@ export class DashboardComponent implements OnInit {
   constructor(private dashboardService: DashboardService) { }
 
   ngOnInit(): void {
-    this.numRunningJobs = 0;
-    this.numCompleteJobs = 0;
-    this.numDraftJobs = 0;
+    // this.numRunningJobs = 0;
+    // this.numCompleteJobs = 0;
+    // this.numDraftJobs = 0;
     localStorage.removeItem("job_id")
     localStorage.removeItem("template_id")
     this.jobs = []
@@ -49,22 +49,21 @@ export class DashboardComponent implements OnInit {
     this.includeRunningJobs=true;
     this.includeDraftJobs=true;
     this.getJobsData()
+    // this.filterJobs();
     // console.log("get jobs again");
   }
 
   getJobsData() {
-    // console.log("getting jobs");
     // this.dashboardService.getMockData()
     this.dashboardService.getJobsData()
       .subscribe(allJobs => {
         allJobs.map(job => {
-          // console.log(job)
           job.case = {links: {self:job['links']['case']},name: job['parent_case'],thumbnail: "string",description: "string"}
           var progressPlaceHolder:ProgressInfo = {"value": 0, "units": "%", "range_min":0, "range_max":100}
           this.jobs.push({"info": job, "progress":progressPlaceHolder})
-          this.filteredJobs.push({"info": job, "progress":progressPlaceHolder})
         })
         this.jobsStillLoading = false;
+        this.filterJobs();
       }
     )
   }
@@ -157,13 +156,20 @@ export class DashboardComponent implements OnInit {
     this.filterJobs();
   }
 
+
   filterJobs() {
+    this.numDraftJobs = 0;
+    this.numRunningJobs = 0;
+    this.numCompleteJobs = 0;
+
     this.filteredJobs = []
     
     this.jobs.map(job => {
       if (this.includeDraftJobs) {
         if ((job.info.status.toLowerCase().indexOf('not started') >= 0)
             &&(job.info.name.toLowerCase().indexOf(this.searchTerm.toLowerCase()) >= 0)) {
+              
+              this.numDraftJobs++;
           this.filteredJobs.push(job)  
         }
       }
@@ -172,12 +178,14 @@ export class DashboardComponent implements OnInit {
         (job.info.status.toLowerCase().indexOf('queued') >= 0))
         &&(job.info.name.toLowerCase().indexOf(this.searchTerm.toLowerCase()) >= 0))  
         {
+          this.numRunningJobs++;
           this.filteredJobs.push(job)  
         }
       }
       if (this.includeCompletedJobs) {
         if ((job.info.status.toLowerCase().indexOf('complete') >= 0)
         &&(job.info.name.toLowerCase().indexOf(this.searchTerm.toLowerCase()) >= 0)) {
+          this.numCompleteJobs++;
           this.filteredJobs.push(job)  
         }
       }

--- a/src/app/dashboard/jobSummary.component.html
+++ b/src/app/dashboard/jobSummary.component.html
@@ -21,6 +21,8 @@
 						class="nav-link">
 							<span class="nav-text">{{jobInfo?.name}} </span>
 					</a>
+					<p class="p2" *ngIf = "routeToQueued" >{{jobInfo?.name}}</p> 
+							
 				</div>
 				<div class="col-lg-4 col-md-4 col-sm-4 col-xs-4"> 
 					<div class="progress demo" style="float:right">
@@ -31,7 +33,7 @@
 
 			<div class="row">
 				<div class="col-lg-6 col-md-6 col-sm-6 col-xs-6"> 
-				based on {{jobInfo?.parent_case.name}}	
+					based on {{jobInfo?.parent_case.name}}
 				</div>
 				<div class="col-lg-6 col-md-6 col-sm-6 col-xs-6" > 
 					<div style="float:right">{{jobInfo?.status}}</div>
@@ -40,6 +42,7 @@
 
 			<div class="row action-row">
 					<div class="col-lg-8 col-md-8 col-sm-12 col-xs-12"> 
+							<!-- <p class="p4" >{{jobShortDescription}}</p>  -->
 							<div class="job-description">{{jobShortDescription}}</div>
 						</div>
 				<div class="col-lg-4 col-md-4 col-sm-4 col-xs-4"> 

--- a/src/app/dashboard/jobSummary.component.ts
+++ b/src/app/dashboard/jobSummary.component.ts
@@ -26,6 +26,7 @@ export class JobSummaryComponent implements OnInit{
     jobProgress:string;
     routeToConfig:boolean
     routeToOutput:boolean
+    routeToQueued: boolean
     stopJobOption:boolean
     hideOptions:boolean
     showConfirmDelete:boolean
@@ -80,9 +81,8 @@ export class JobSummaryComponent implements OnInit{
 
     getActionRoute() : string  {
         switch (this.jobInfo.status.toLowerCase()) {
-            case "complete": return "['/output/output']";
+            case "completed": return "['/output/output']";
             case "running": return "['/output/output']";
-            case "queued": return "['/output/output']";
             case "not started": return "['/config/config']";
             case "new": return "['/config/config']";
             default: return "['/output/output']";
@@ -133,6 +133,12 @@ export class JobSummaryComponent implements OnInit{
         switch (this.jobInfo.status.toLowerCase()) {
             case "completed": return true;
             case "running": return true;
+            default: return false;
+        }
+    }
+
+    drawRouteToQueued() : boolean  {
+        switch (this.jobInfo.status.toLowerCase()) {
             case "queued": return true;
             default: return false;
         }
@@ -157,6 +163,7 @@ export class JobSummaryComponent implements OnInit{
         this.jobProgress = this.getProgress()
         this.routeToConfig=this.drawRouteToConfig()
         this.routeToOutput =this.drawRouteToOutput()
+        this.routeToQueued =this.drawRouteToQueued()
         this.stopJobOption = this.drawPauseOption()
         this.actionButtonRoute = this.getActionRoute()
         this.hideOptions = true

--- a/src/app/output/download/download.component.ts
+++ b/src/app/output/download/download.component.ts
@@ -38,7 +38,7 @@ export class DownloadComponent implements OnInit {
           break;
         }
         case 'zip': {
-          this.downloadFilename = 'zip.mp4'
+          this.downloadFilename = 'siMulate.zip'
           this.buttonLabel = 'Zip (.zip)'
           break;
         }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -7,12 +7,12 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="BlueWeb">
-    <meta name="author" content="Blue">
+    <meta name="description" content="SiMulate">
+    <meta name="author" content="SiMulate">
     <meta name="keyword" content="Bootstrap,Admin,Template,Open,Source,AngularJS,Angular,Angular2,jQuery,CSS,HTML,RWD,Dashboard">
      <link rel="shortcut icon" href="assets/img/favicon.png">
 
-    <title>BlueWeb</title>
+    <title>SiMulate</title>
 
 </head>
 


### PR DESCRIPTION
1. Disable link to edit or results page when job is queued (no results to show, prevent resending job)
2. Remove references to Blue
3. Badges showing number of jobs filtered by status updated.
4. Text showing number of jobs returned based on search term updated. 