### PR TITLE
Prevent clarity module elements from being declared in output component…

### DIFF
--- a/src/app/output/download/download.component.ts
+++ b/src/app/output/download/download.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { OutputService } from '../output.service';
 import * as FileSaver from 'file-saver';
-import "clarity-icons";
 
 @Component({
     providers: [OutputService],

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -19,7 +19,7 @@ import 'web-animations-js/web-animations.min';
 
 // Clarity Icons
 import 'clarity-icons/clarity-icons.min.css';
-import 'clarity-icons/clarity-icons.min';
+import 'clarity-icons/clarity-icons.min.js';
 
 // Clarity UI
 import 'clarity-ui/clarity-ui.min.css';


### PR DESCRIPTION
…, where element names clashed with custom registered element names.