### PR TITLE
Azure production

### DIFF
--- a/src/app/core/services/token.interceptor.ts
+++ b/src/app/core/services/token.interceptor.ts
@@ -5,12 +5,15 @@ import {
   HttpEvent,
   HttpInterceptor,
 } from '@angular/common/http';
+import { environment } from '@env/environment';
 
 import { Observable } from 'rxjs/Observable';
 import { TokenService, DA_SERVICE_TOKEN } from '@delon/auth';
 
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
+  private tokenBypass = environment.tokenBypass;
+
   constructor(
     @Inject(DA_SERVICE_TOKEN) private tokenService: TokenService, // @Inject() for singleton service
   ) {}
@@ -19,18 +22,28 @@ export class TokenInterceptor implements HttpInterceptor {
     request: HttpRequest<any>,
     next: HttpHandler,
   ): Observable<HttpEvent<any>> {
-    if (request.responseType == 'blob') {
-      return next.handle(request);
-    } else {
-      let token = this.tokenService.get()['token'];
+    // skip interceptor based on specified url fragments
+    // for example: interceptor should not apply tokens for storage calls
+    // as substitute tokens already appear as url query parameters
 
-      request = request.clone({
-        setHeaders: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+    let urlSkip = false;
+    this.tokenBypass.forEach(fragment => {
+      if (request.url.includes(fragment)) {
+        urlSkip = true;
+      }
+    });
 
+    if (urlSkip) {
       return next.handle(request);
     }
+
+    let token = this.tokenService.get()['token'];
+    request = request.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return next.handle(request);
   }
 }

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -1,6 +1,7 @@
 export const environment = {
-  AUTH_URL: `http://localhost:5050`,
-  MIDDLEWARE_URL: `http://localhost:5000`,
+  AUTH_URL: 'http://localhost:5050',
+  MIDDLEWARE_URL: 'http://localhost:5000',
+  tokenBypass: ['core.windows.net'],
   production: true,
   useHash: false,
   hmr: false,

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -1,6 +1,6 @@
 export const environment = {
-  AUTH_URL: `http://simulate.uksouth.cloudapp.azure.com:5050`,
-  MIDDLEWARE_URL: `http://simulate.uksouth.cloudapp.azure.com:5000`,
+  AUTH_URL: `http://localhost:5050`,
+  MIDDLEWARE_URL: `http://localhost:5000`,
   production: true,
   useHash: false,
   hmr: false,

--- a/src/environments/environment.hmr.ts
+++ b/src/environments/environment.hmr.ts
@@ -1,6 +1,7 @@
 export const environment = {
-  AUTH_URL: `http://localhost:5050`,
-  MIDDLEWARE_URL: `http://localhost:5000`,
+  AUTH_URL: 'http://localhost:5050',
+  MIDDLEWARE_URL: 'http://localhost:5000',
+  tokenBypass: ['core.windows.net'],
   production: false,
   useHash: false,
   hmr: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
-  AUTH_URL: `http://localhost:5050`,
-  MIDDLEWARE_URL: `http://localhost:5000`,
+  AUTH_URL: 'http://localhost:5050',
+  MIDDLEWARE_URL: 'http://localhost:5000',
+  tokenBypass: ['core.windows.net'],
   production: false,
   useHash: false,
   hmr: false,


### PR DESCRIPTION
Support https://github.com/alan-turing-institute/simulate/issues/103.

* Introduce a config list `tokenBypass`, for example:

```typescript
tokenBypass: ['core.windows.net']
```

Requests containing 'core.windows.net' will bypass the token interceptor and remain token free. All other requests will have a token attached to them.
